### PR TITLE
fix(text-node):apply bold for monospace and code modes

### DIFF
--- a/apps/app/src/app/components/text-preview/index.tsx
+++ b/apps/app/src/app/components/text-preview/index.tsx
@@ -14,7 +14,19 @@ interface TextPreviewProps {}
  */
 const TextPreview: FC<TextPreviewProps> = () => {
   return (
-    <Page wrap size="A4">
+    <Page wrap size="A4" style={{ fontFamily: 'EBGaramond12' }}>
+      <TextNode monospace bold>
+        MonoSpcace - bold ut aliquip ex ea commodo consequat. Duis aute irure
+        dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
+        nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+        culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum dolor
+        sit
+      </TextNode>
+
+      <TextNode monospace>
+        MonoSpcace - ut aliquip ex ea commodo consequat. Duis aute irure dolor
+        in reprehenderit in voluptate velit esse cillum
+      </TextNode>
       <TextNode
         lineHeight={1.5}
         fontSize={12}

--- a/libs/react-pdf-components/src/lib/components/text-node/text-node.tsx
+++ b/libs/react-pdf-components/src/lib/components/text-node/text-node.tsx
@@ -50,9 +50,6 @@ const styles = StyleSheet.create({
   underline: {
     textDecoration: 'underline',
   },
-  underlineStrikeThrough: {
-    textDecoration: 'underline line-through',
-  },
   strikeThrough: {
     textDecoration: 'line-through',
   },
@@ -69,6 +66,17 @@ const styles = StyleSheet.create({
     fontVariant: 'small-caps',
   },
   baseStyles: {},
+
+  // special styles
+  underlineStrikeThrough: {
+    textDecoration: 'underline line-through',
+  },
+  codeBold: {
+    fontFamily: 'Courier-Bold',
+  },
+  monospaceBold: {
+    fontFamily: 'Courier-Bold',
+  },
 });
 
 const featureToStyleMap: Record<keyof Features, keyof typeof styles> = {
@@ -120,9 +128,15 @@ export const TextNode: FunctionComponent<TextNodeProps> = ({
     }
   };
   const handleSpecialStyles = () => {
-    if (otherProps.underline && otherProps.strikeThrough)
-      //handle spacial style cases --->
+    //handle spacial style cases
+    const { underline, strikeThrough, code, bold, monospace } = otherProps;
+    if (underline && strikeThrough) {
       composedStyles.push(styles.underlineStrikeThrough);
+    } else if (code && bold) {
+      composedStyles.push(styles.codeBold);
+    } else if (monospace && bold) {
+      composedStyles.push(styles.monospaceBold);
+    }
   };
 
   composeStyles();


### PR DESCRIPTION
- Now text node uses 'Courier-Bold' font when monospace applied with bold
- To apply bold for monospace/code,
    > pass `bold` prop.
    >             or
    > pass `fontFamily:"Courier-Bold"` as a style.