### PR TITLE
fix(chapter): stop rendering full-bleed bg images

### DIFF
--- a/libs/react-pdf-components/src/lib/components/chapter/chapter.tsx
+++ b/libs/react-pdf-components/src/lib/components/chapter/chapter.tsx
@@ -126,13 +126,10 @@ export const Chapter: FC<ChapterProps> = ({
       }
       style={[styleSheet.page]}
     >
-      {/* bg-image */}
+      {/* full-bleed bg-image */}
 
-      {backgroundImageSrc && (
-        <RPDFView
-          fixed={assumeUsingOnlyFirstPage}
-          style={styleSheet.fullBleedImageContainer}
-        >
+      {backgroundImageSrc && assumeUsingOnlyFirstPage && (
+        <RPDFView fixed style={styleSheet.fullBleedImageContainer}>
           <RPDFImage
             src={
               backgroundImageSrc && !disableImageSrcURLAppends


### PR DESCRIPTION
Stop rendering full-bleed background images if
"assumeUsingOnlyFirstPage" parameter is false.

This prevents the image container leaking into 2 pages.