### PR TITLE
Fix/text-node-styles

### DIFF
--- a/apps/app/src/app/components/float-preview/index.tsx
+++ b/apps/app/src/app/components/float-preview/index.tsx
@@ -38,7 +38,7 @@ const FloatPreview: FC<FloatPreviewProps> = () => {
         error ipsam debitis.
       </TextNode>
       <TextNode> </TextNode>
-      <TextNode fontSize={16} code>
+      <TextNode fontSize={16}>
         Code, ipsum dolor sit amet consectetur adipisicing elit. Numquam fugiat
         qui eosquod asperiores provident, quo deleniti vel velit ducimus
         suscipit vitae error ipsam debitis. Numquam fugiat qui eosquod

--- a/apps/app/src/app/components/text-preview/index.tsx
+++ b/apps/app/src/app/components/text-preview/index.tsx
@@ -15,7 +15,7 @@ interface TextPreviewProps {}
 const TextPreview: FC<TextPreviewProps> = () => {
   return (
     <Page wrap size="A4" style={{ fontFamily: 'EBGaramond12' }}>
-      <TextNode monospace bold>
+      <TextNode bold>
         MonoSpcace - bold ut aliquip ex ea commodo consequat. Duis aute irure
         dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
         nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
@@ -23,7 +23,7 @@ const TextPreview: FC<TextPreviewProps> = () => {
         sit
       </TextNode>
 
-      <TextNode monospace>
+      <TextNode>
         MonoSpcace - ut aliquip ex ea commodo consequat. Duis aute irure dolor
         in reprehenderit in voluptate velit esse cillum
       </TextNode>
@@ -43,7 +43,7 @@ const TextPreview: FC<TextPreviewProps> = () => {
           dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
           incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
         </TextNode>
-        <TextNode sansSerif> quis nostrud exercitation ullamco </TextNode>
+        <TextNode> quis nostrud exercitation ullamco </TextNode>
         <TextNode>
           laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor
           in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
@@ -139,7 +139,7 @@ const TextPreview: FC<TextPreviewProps> = () => {
       <TextNode>
         1. <TextNode>Listed item</TextNode>
       </TextNode>
-      <TextNode fontSize={16} code>
+      <TextNode fontSize={16}>
         Code, ipsum dolor sit amet consectetur adipisicing elit. Numquam fugiat
         qui eosquod asperiores provident, quo deleniti vel velit ducimus
         suscipit vitae error ipsam debitis.

--- a/libs/react-pdf-components/src/lib/components/text-node/text-node.tsx
+++ b/libs/react-pdf-components/src/lib/components/text-node/text-node.tsx
@@ -4,23 +4,6 @@ import ReactPDF, {
 } from '@paladin-analytics/rpdf-renderer';
 import { FunctionComponent } from 'react';
 
-/**
- * Atticus :: TextNode features
- *
- * *bold
- * *italic
- * *underline
- * *strikethrough
- * *superscript
- * *subscript
- * *smallcaps
- * *code       [Courier]--> add other font types
- * *monospace  [Courier]--> add other font types
- * *sansserif  [PT Sans]--> add other font types
- * ?dropcap
- *
- */
-
 type Features = {
   superscript?: boolean;
   subscript?: boolean;
@@ -28,10 +11,7 @@ type Features = {
   italic?: boolean;
   underline?: boolean;
   strikeThrough?: boolean;
-  code?: boolean;
   smallCaps?: boolean;
-  monospace?: boolean;
-  sansSerif?: boolean;
 };
 
 const styles = StyleSheet.create({
@@ -53,15 +33,6 @@ const styles = StyleSheet.create({
   strikeThrough: {
     textDecoration: 'line-through',
   },
-  code: {
-    fontFamily: 'CourierPrime',
-  },
-  sansSerif: {
-    fontFamily: 'PTSans',
-  },
-  monospace: {
-    fontFamily: 'CourierPrime',
-  },
   smallCaps: {
     fontVariant: 'small-caps',
   },
@@ -70,12 +41,6 @@ const styles = StyleSheet.create({
   // special styles
   underlineStrikeThrough: {
     textDecoration: 'underline line-through',
-  },
-  codeBold: {
-    fontFamily: 'CourierPrime',
-  },
-  monospaceBold: {
-    fontFamily: 'CourierPrime',
   },
 });
 
@@ -86,10 +51,7 @@ const featureToStyleMap: Record<keyof Features, keyof typeof styles> = {
   italic: 'italic',
   underline: 'underline',
   strikeThrough: 'strikeThrough',
-  code: 'code',
-  monospace: 'monospace',
   smallCaps: 'smallCaps',
-  sansSerif: 'sansSerif',
 };
 
 export interface TextNodeProps extends ReactPDF.TextProps, Features {
@@ -129,13 +91,9 @@ export const TextNode: FunctionComponent<TextNodeProps> = ({
   };
   const handleSpecialStyles = () => {
     //handle spacial style cases
-    const { underline, strikeThrough, code, bold, monospace } = otherProps;
+    const { underline, strikeThrough } = otherProps;
     if (underline && strikeThrough) {
       composedStyles.push(styles.underlineStrikeThrough);
-    } else if (code && bold) {
-      composedStyles.push(styles.codeBold);
-    } else if (monospace && bold) {
-      composedStyles.push(styles.monospaceBold);
     }
   };
 

--- a/libs/react-pdf-components/src/lib/components/text-node/text-node.tsx
+++ b/libs/react-pdf-components/src/lib/components/text-node/text-node.tsx
@@ -54,13 +54,13 @@ const styles = StyleSheet.create({
     textDecoration: 'line-through',
   },
   code: {
-    fontFamily: 'Courier',
+    fontFamily: 'CourierPrime',
   },
   sansSerif: {
-    fontFamily: 'PT Sans',
+    fontFamily: 'PTSans',
   },
   monospace: {
-    fontFamily: 'Courier',
+    fontFamily: 'CourierPrime',
   },
   smallCaps: {
     fontVariant: 'small-caps',
@@ -72,10 +72,10 @@ const styles = StyleSheet.create({
     textDecoration: 'underline line-through',
   },
   codeBold: {
-    fontFamily: 'Courier-Bold',
+    fontFamily: 'CourierPrime',
   },
   monospaceBold: {
-    fontFamily: 'Courier-Bold',
+    fontFamily: 'CourierPrime',
   },
 });
 


### PR DESCRIPTION
Remove properties that the text-node is not responsible for -- `code`,  `monospace`,  `sansSerif`