### PR TITLE
fix: list item content spilling to next page

### DIFF
--- a/libs/react-pdf-components/src/lib/components/list-item/list-item.tsx
+++ b/libs/react-pdf-components/src/lib/components/list-item/list-item.tsx
@@ -73,6 +73,7 @@ export const Item: FC<{
         ...styles.itemContainer,
         marginBottom: style?.lineHeight || getFontSize(style?.fontSize),
       }}
+      wrap={false}
     >
       <RPDFView
         style={{


### PR DESCRIPTION
Fix the notes list splitting with the number on one page and the text on the next in the pdf version.

(Part of AT-295)